### PR TITLE
Add a truncation method for extract

### DIFF
--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -127,6 +127,7 @@ class Exporter:
             # remove file redirections
             wad.files = [wf for wf in wad.files if wf.type != 2]
             wad.guess_extensions()
+            wad.sanitize_paths()
             self.wads[export_path] = wad
         else:
             self.plain_files[export_path] = source_path
@@ -605,4 +606,3 @@ class SknConverter(FileConverter):
             name = os.path.join(path, entry["name"] + ".obj")
             with open(name, "w") as f:
                 f.write(sknfile.to_obj(entry))
-

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -232,7 +232,7 @@ class Wad:
                     continue
 
                 basename, ext = os.path.splitext(filename)
-                wadfile.path = os.path.join(path, f"{basename[:255-21]}.{hex(wadfile.path_hash)[2:]}{ext}")
+                wadfile.path = os.path.join(path, f"{basename[:255-17-len(ext)]}.{wadfile.path_hash:016x}{ext}")
 
     def extract(self, output, overwrite=True):
         """Extract WAD file

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -222,6 +222,17 @@ class Wad:
                 else:
                     wadfile.path = f"{path}/{wadfile.path_hash:016x}"
 
+    def sanitize_paths(self):
+        """Truncate files that have a length of over 255"""
+
+        for wadfile in self.files:
+            path, filename = os.path.split(wadfile.path)
+            if (len(filename) < 256):
+                continue
+
+            basename, ext = os.path.splitext(filename)
+            wadfile.path = os.path.join(path, basename[:255-21] + "." + hex(wadfile.path_hash)[2:] + ext)
+
     def extract(self, output, overwrite=True):
         """Extract WAD file
 
@@ -231,6 +242,7 @@ class Wad:
         logger.info(f"extracting {self.path} to {output}")
 
         self.set_unknown_paths("unknown")
+        self.sanitize_paths()
 
         with open(self.path, 'rb') as fwad:
             for wadfile in self.files:

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -223,15 +223,16 @@ class Wad:
                     wadfile.path = f"{path}/{wadfile.path_hash:016x}"
 
     def sanitize_paths(self):
-        """Truncate files that have a length of over 255"""
+        """Truncate files whose basename has a length of at least 255"""
 
         for wadfile in self.files:
-            path, filename = os.path.split(wadfile.path)
-            if (len(filename) < 256):
-                continue
+            if wadfile.path:
+                path, filename = os.path.split(wadfile.path)
+                if len(filename) < 255:
+                    continue
 
-            basename, ext = os.path.splitext(filename)
-            wadfile.path = os.path.join(path, basename[:255-21] + "." + hex(wadfile.path_hash)[2:] + ext)
+                basename, ext = os.path.splitext(filename)
+                wadfile.path = os.path.join(path, f"{basename[:255-21]}.{hex(wadfile.path_hash)[2:]}{ext}")
 
     def extract(self, output, overwrite=True):
         """Extract WAD file


### PR DESCRIPTION
Made mainly because of the ``data/skins_skinxx_skins_skinxx.....bin`` files which could become so large they can't be fully extracted on a normal file system because of the 255 character component limit. Open for suggestions regarding code style and general functionality.