### PR TITLE
Serialize type of STRUCT instead of empty dictionary

### DIFF
--- a/cdragontoolbox/binfile.py
+++ b/cdragontoolbox/binfile.py
@@ -158,8 +158,9 @@ class BinObjectWithFields:
             return default
 
     def to_serializable(self):
-        return dict(f.to_serializable() for f in self.fields)
-
+        result = dict(f.to_serializable() for f in self.fields)
+        result["__type"] = self.type.to_serializable()
+        return result
 
 class BinType(IntEnum):
     # See parse_bintype() for remapping depending on version
@@ -240,12 +241,7 @@ class BinContainerField(BinField):
         return f"<{self.name!r} CONTAINER({self.type.name}) {svalues}>"
 
     def to_serializable(self):
-        serialized_values = [_to_serializable(v) for v in self.value]
-        for i, v in enumerate(serialized_values):
-            if v == {}:
-                serialized_values[i] = self.value[i].type.to_serializable()
-
-        return (self.name.to_serializable(), serialized_values)
+        return (self.name.to_serializable(), [_to_serializable(v) for v in self.value])
 
 class BinStructField(BinField):
     def __init__(self, hname, value):
@@ -257,8 +253,7 @@ class BinStructField(BinField):
         return f"<{self.name!r} STRUCT {self.value.type!r} {sfields}>"
 
     def to_serializable(self):
-        serialized_value = self.value.to_serializable()
-        return (self.name.to_serializable(), self.value.type.to_serializable() if serialized_value == {} else serialized_value)
+        return (self.name.to_serializable(), self.value.to_serializable())
 
 class BinEmbeddedField(BinField):
     def __init__(self, hname, value):

--- a/cdragontoolbox/binfile.py
+++ b/cdragontoolbox/binfile.py
@@ -240,7 +240,12 @@ class BinContainerField(BinField):
         return f"<{self.name!r} CONTAINER({self.type.name}) {svalues}>"
 
     def to_serializable(self):
-        return (self.name.to_serializable(), [_to_serializable(v) for v in self.value])
+        serialized_values = [_to_serializable(v) for v in self.value]
+        for i, v in enumerate(serialized_values):
+            if v == {}:
+                serialized_values[i] = self.value[i].type.to_serializable()
+
+        return (self.name.to_serializable(), serialized_values)
 
 class BinStructField(BinField):
     def __init__(self, hname, value):
@@ -252,7 +257,8 @@ class BinStructField(BinField):
         return f"<{self.name!r} STRUCT {self.value.type!r} {sfields}>"
 
     def to_serializable(self):
-        return (self.name.to_serializable(), self.value.to_serializable())
+        serialized_value = self.value.to_serializable()
+        return (self.name.to_serializable(), self.value.type.to_serializable() if serialized_value == {} else serialized_value)
 
 class BinEmbeddedField(BinField):
     def __init__(self, hname, value):


### PR DESCRIPTION
For my application I needed some information about spell data that was missing because it was in a struct that was not being serialized (it was an empty dict in the resulting json). Thing is that the name alone of the unserialized struct can convey enough information about the spell.

Take a look at the following image showcasing the json differences before/after the code I wrote:

![image](https://user-images.githubusercontent.com/8768822/104333473-efb2e280-54f9-11eb-8e98-03dba414788e.png)

As you can see for example mTargetingTypeData tells us what type of spell are we dealing with values can be Cone, Location, Area. Also there is important information that can be extracted from the type of the struct for behaviours.