### PR TITLE
Support reading subchunked wad entries using the .subchunktoc file

### DIFF
--- a/cdragontoolbox/data.py
+++ b/cdragontoolbox/data.py
@@ -37,3 +37,9 @@ class Language(Enum):
     zh_cn = 'zh_cn'
     zh_my = 'zh_my'
     zh_tw = 'zh_tw'
+
+class MalformedSubchunkException(BaseException):
+    """Subchunk data is invalid or doesn't match the provided subchunktoc"""
+
+    def __init__(self, data):
+        self.wad_data = data

--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -313,7 +313,7 @@ class Exporter:
                 if not overwrite and converter.converted_paths_exist(self.output, wadfile.path):
                     continue
 
-                data = wadfile.read_data(fwad)
+                data = wadfile.read_data(fwad, wad.subchunkTOC)
                 if data is None:
                     continue  # should not happen, file redirections have been filtered already
 

--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from PIL import Image
 
 from .storage import PatchVersion
-from .wad import Wad
+from .wad import Wad, MalformedSubchunkException
 from .binfile import BinFile
 from .sknfile import SknFile
 from .rstfile import hashfile_rst, RstFile, key_to_hash as key_to_rsthash
@@ -313,7 +313,10 @@ class Exporter:
                 if not overwrite and converter.converted_paths_exist(self.output, wadfile.path):
                     continue
 
-                data = wadfile.read_data(fwad, wad.subchunk_toc)
+                try:
+                    data = wadfile.read_data(fwad, wad.subchunk_toc)
+                except MalformedSubchunkException:
+                    continue # prefer not exporting anything than exporting a wrong file
                 if data is None:
                     continue  # should not happen, file redirections have been filtered already
 

--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -313,7 +313,7 @@ class Exporter:
                 if not overwrite and converter.converted_paths_exist(self.output, wadfile.path):
                     continue
 
-                data = wadfile.read_data(fwad, wad.subchunkTOC)
+                data = wadfile.read_data(fwad, wad.subchunk_toc)
                 if data is None:
                     continue  # should not happen, file redirections have been filtered already
 

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from typing import Dict
 from xxhash import xxh64_intdigest
 from .data import REGIONS, Language
+from .wad import MalformedSubchunkException
 
 logger = logging.getLogger(__name__)
 
@@ -744,7 +745,10 @@ class GameHashGuesser(HashGuesser):
                                    'skl', 'skn', 'scb', 'sco', 'troybin', 'luabin', 'luabin64', 'bnk', 'wpk'):
                     continue # don't grep filetypes known to not contain full paths
 
-                data = wadfile.read_data(f, wad.subchunk_toc)
+                try:
+                    data = wadfile.read_data(f, wad.subchunk_toc)
+                except MalformedSubchunkException:
+                    continue
                 if wadfile.ext in ('bin', 'inibin'):
                     # bin files: find strings based on prefix, then parse the length
                     for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay)/', data):

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -744,7 +744,7 @@ class GameHashGuesser(HashGuesser):
                                    'skl', 'skn', 'scb', 'sco', 'troybin', 'luabin', 'luabin64', 'bnk', 'wpk'):
                     continue # don't grep filetypes known to not contain full paths
 
-                data = wadfile.read_data(f)
+                data = wadfile.read_data(f, wad.subchunkTOC)
                 if wadfile.ext in ('bin', 'inibin'):
                     # bin files: find strings based on prefix, then parse the length
                     for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay)/', data):

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -11,8 +11,7 @@ import logging
 from contextlib import contextmanager
 from typing import Dict
 from xxhash import xxh64_intdigest
-from .data import REGIONS, Language
-from .wad import MalformedSubchunkException
+from .data import REGIONS, Language, MalformedSubchunkException
 
 logger = logging.getLogger(__name__)
 

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -744,7 +744,7 @@ class GameHashGuesser(HashGuesser):
                                    'skl', 'skn', 'scb', 'sco', 'troybin', 'luabin', 'luabin64', 'bnk', 'wpk'):
                     continue # don't grep filetypes known to not contain full paths
 
-                data = wadfile.read_data(f, wad.subchunkTOC)
+                data = wadfile.read_data(f, wad.subchunk_toc)
                 if wadfile.ext in ('bin', 'inibin'):
                     # bin files: find strings based on prefix, then parse the length
                     for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay)/', data):

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -32,8 +32,6 @@ _hash_to_guessed_extensions = {}
 class MalformedSubchunkException(BaseException):
     """Subchunk data is invalid or doesn't match the provided subchunktoc"""
 
-    wad_data = None
-
     def __init__(self, data):
         self.wad_data = data
 

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -13,6 +13,7 @@ from .tools import (
     write_file_or_remove,
     zstd_decompress,
 )
+from .data import MalformedSubchunkException
 
 def test_jpeg_photoshop(h, f):
     if h[:4] == b'\xff\xd8\xff\xe1':
@@ -28,12 +29,6 @@ logger = logging.getLogger(__name__)
 # Caching is possible because the same hash should always have the same extension. Since guessing extension requires to
 # read file data, caching will reduce I/Os
 _hash_to_guessed_extensions = {}
-
-class MalformedSubchunkException(BaseException):
-    """Subchunk data is invalid or doesn't match the provided subchunktoc"""
-
-    def __init__(self, data):
-        self.wad_data = data
 
 class WadFileHeader:
     """Single file entry in a WAD archive"""


### PR DESCRIPTION
This also fixes an exception currently occuring on PBE when parsing the `Warwick.wad.client` file (from manifest https://lol.secure.dyn.riotcdn.net/channels/public/releases/04C8D70DFF45D23B.manifest):
```py
Traceback (most recent call last):
  File "D:\GitHub\CDTB\grep_wads.py", line 34, in <module>
    wad.guess_extensions()
  File "D:\GitHub\CDTB\cdragontoolbox\wad.py", line 214, in guess_extensions
    data = wadfile.read_data(f)
  File "D:\GitHub\CDTB\cdragontoolbox\wad.py", line 97, in read_data
    return zstd_decompress(data)
pyzstd.ZstdError: Unable to decompress zstd data: Unknown frame descriptor.
```
The failing (wad-)file in particular has hash `F5B498022C64E681` (`assets/characters/warwick/skins/skin46/particles/winterblessed_warwick_colorblue_01.pie_c_12_23.tex`) and it fails because the first subchunk is uncompressed, while the second and third are.

The fact that the subchunktoc file path must be known before being able to effectively handle files is a big issue of this implementation, but I don't see how this can be done better.
I also contemplated making an own class for the subchunktoc file entries (u32 compressed size, u32 uncompressed size, u64 xxhash of data), but decided against it for now as it didn't seem necessary.