### PR TITLE
Add AssociatedTraits and IncompatibleTraits to TFT item and augment data

### DIFF
--- a/cdragontoolbox/tftdata.py
+++ b/cdragontoolbox/tftdata.py
@@ -178,6 +178,14 @@ class TftTransformer:
 
     def parse_items(self, map22):
         item_entries = [x for x in map22.entries if x.type == "TftItemData"]
+        trait_entries = [x for x in map22.entries if x.type == "TftTraitData"]
+
+        traits_by_hash = {}
+        for trait in trait_entries:
+            trait_apiName = trait.getv("mName")
+            if "Template" in trait_apiName:
+                continue
+            traits_by_hash[trait.path.h] = trait_apiName
 
         items = []
         items_by_hash = {}  # {item_hash: item}
@@ -199,6 +207,8 @@ class TftTransformer:
                 "icon": item.getv("mIconPath"),
                 "unique": item.getv(0x9596A387, False),
                 "composition": [x.h for x in item.getv(0x8B83BA8A, [])],  # updated below
+                "AssociatedTraits": [x.h for x in item.getv("AssociatedTraits", [])], # updated below
+                "IncompatibleTraits": [x.h for x in item.getv("IncompatibleTraits", [])], # updated below
                 "effects": effects,
             }
             items.append(item_data)
@@ -212,7 +222,8 @@ class TftTransformer:
             else:
                 item["from"] = None
             item["composition"] = [items_by_hash[h]["apiName"] for h in item["composition"]]
-
+            item["IncompatibleTraits"] = [traits_by_hash[h] for h in item["IncompatibleTraits"]]
+            item["AssociatedTraits"] = [traits_by_hash[h] for h in item["AssociatedTraits"]]
         return items
 
     def parse_champs(self, map22, traits, character_folder):

--- a/cdragontoolbox/tftdata.py
+++ b/cdragontoolbox/tftdata.py
@@ -183,8 +183,6 @@ class TftTransformer:
         traits_by_hash = {}
         for trait in trait_entries:
             trait_apiName = trait.getv("mName")
-            if "Template" in trait_apiName:
-                continue
             traits_by_hash[trait.path.h] = trait_apiName
 
         items = []

--- a/cdragontoolbox/tftdata.py
+++ b/cdragontoolbox/tftdata.py
@@ -180,10 +180,7 @@ class TftTransformer:
         item_entries = [x for x in map22.entries if x.type == "TftItemData"]
         trait_entries = [x for x in map22.entries if x.type == "TftTraitData"]
 
-        traits_by_hash = {}
-        for trait in trait_entries:
-            trait_apiName = trait.getv("mName")
-            traits_by_hash[trait.path.h] = trait_apiName
+        traits_by_hash = {trait.path.h: trait.getv("mName") for trait in trait_entries}
 
         items = []
         items_by_hash = {}  # {item_hash: item}

--- a/cdragontoolbox/tftdata.py
+++ b/cdragontoolbox/tftdata.py
@@ -207,8 +207,8 @@ class TftTransformer:
                 "icon": item.getv("mIconPath"),
                 "unique": item.getv(0x9596A387, False),
                 "composition": [x.h for x in item.getv(0x8B83BA8A, [])],  # updated below
-                "AssociatedTraits": [x.h for x in item.getv("AssociatedTraits", [])], # updated below
-                "IncompatibleTraits": [x.h for x in item.getv("IncompatibleTraits", [])], # updated below
+                "associatedTraits": [x.h for x in item.getv("AssociatedTraits", [])], # updated below
+                "incompatibleTraits": [x.h for x in item.getv("IncompatibleTraits", [])], # updated below
                 "effects": effects,
             }
             items.append(item_data)
@@ -222,8 +222,8 @@ class TftTransformer:
             else:
                 item["from"] = None
             item["composition"] = [items_by_hash[h]["apiName"] for h in item["composition"]]
-            item["IncompatibleTraits"] = [traits_by_hash[h] for h in item["IncompatibleTraits"]]
-            item["AssociatedTraits"] = [traits_by_hash[h] for h in item["AssociatedTraits"]]
+            item["incompatibleTraits"] = [traits_by_hash[h] for h in item["incompatibleTraits"]]
+            item["associatedTraits"] = [traits_by_hash[h] for h in item["associatedTraits"]]
         return items
 
     def parse_champs(self, map22, traits, character_folder):


### PR DESCRIPTION
Adds AssociatedTraits and IncompatibleTraits from map22.bin to item and augment data.

AssociatedTraits seems to be the rules that augments use for being offered, and is useful to associate an augment with the trait it gives ie. "TFT8_Augment_InterPolarisTrait" (LaserCorps Heart) gives +1 "Set8_SpaceCorps"

IncompatibleTraits (not sure why its named this but kept the name) seems to be the trait that spatula items are associated with ie "TFT8_Item_OxForceEmblemItem" (OxForce emblem) gives +1 "Set8_OxForce"
