### PR TITLE
Improve and fix RMAN manifest parsing

### DIFF
--- a/cdragontoolbox/patcher.py
+++ b/cdragontoolbox/patcher.py
@@ -179,7 +179,7 @@ class PatcherManifest:
 
         bundle = PatcherBundle(fields['bundle_id'])
         parser.seek(fields['chunks_offset'])
-        for (chunk_id, compressed_size, uncompressed_size) in PatcherManifest._parse_table(parser, parse_chunklist):
+        for (chunk_id, compressed_size, uncompressed_size) in cls._parse_table(parser, parse_chunklist):
             bundle.add_chunk(chunk_id, compressed_size, uncompressed_size)
 
         return bundle

--- a/cdragontoolbox/patcher.py
+++ b/cdragontoolbox/patcher.py
@@ -160,21 +160,21 @@ class PatcherManifest:
             yield entry_parser(parser)
             parser.seek(pos + 4)
 
-    @staticmethod
-    def _parse_bundle(parser):
+    @classmethod
+    def _parse_bundle(cls, parser):
         """Parse a bundle entry"""
 
         def parse_chunklist(parser):
-            fields = PatcherManifest._parse_field_table(parser, (
+            fields = cls._parse_field_table(parser, (
                 ('chunk_id', '<Q'),
                 ('compressed_size', '<L'),
-                ('uncompressed_size', '<L')
+                ('uncompressed_size', '<L'),
             ))
             yield fields['chunk_id'], fields['compressed_size'], fields['uncompressed_size']
 
-        fields = PatcherManifest._parse_field_table(parser, (
+        fields = cls._parse_field_table(parser, (
             ('bundle_id', '<Q'),
-            ('chunks_offset', 'offset')
+            ('chunks_offset', 'offset'),
         ))
 
         bundle = PatcherBundle(fields['bundle_id'])

--- a/cdragontoolbox/patcher.py
+++ b/cdragontoolbox/patcher.py
@@ -170,7 +170,7 @@ class PatcherManifest:
                 ('compressed_size', '<L'),
                 ('uncompressed_size', '<L'),
             ))
-            yield fields['chunk_id'], fields['compressed_size'], fields['uncompressed_size']
+            return fields['chunk_id'], fields['compressed_size'], fields['uncompressed_size']
 
         fields = cls._parse_field_table(parser, (
             ('bundle_id', '<Q'),
@@ -179,7 +179,7 @@ class PatcherManifest:
 
         bundle = PatcherBundle(fields['bundle_id'])
         parser.seek(fields['chunks_offset'])
-        for (chunk_id, compressed_size, uncompressed_size), in PatcherManifest._parse_table(parser, parse_chunklist):
+        for (chunk_id, compressed_size, uncompressed_size) in PatcherManifest._parse_table(parser, parse_chunklist):
             bundle.add_chunk(chunk_id, compressed_size, uncompressed_size)
 
         return bundle

--- a/cdragontoolbox/patcher.py
+++ b/cdragontoolbox/patcher.py
@@ -163,20 +163,24 @@ class PatcherManifest:
     @staticmethod
     def _parse_bundle(parser):
         """Parse a bundle entry"""
-        _, n, bundle_id = parser.unpack('<llQ')
-        # skip remaining header part, if any
-        parser.skip(n - 12)
 
-        bundle = PatcherBundle(bundle_id)
-        n, = parser.unpack('<l')
-        for _ in range(n):
-            pos = parser.tell()
-            offset, = parser.unpack('<l')
-            parser.seek(pos + offset)
-            parser.skip(4)  # skip offset table offset
-            compressed_size, uncompressed_size, chunk_id = parser.unpack('<LLQ')
+        def parse_chunklist(parser):
+            fields = PatcherManifest._parse_field_table(parser, (
+                ('chunk_id', '<Q'),
+                ('compressed_size', '<L'),
+                ('uncompressed_size', '<L')
+            ))
+            yield fields['chunk_id'], fields['compressed_size'], fields['uncompressed_size']
+
+        fields = PatcherManifest._parse_field_table(parser, (
+            ('bundle_id', '<Q'),
+            ('chunks_offset', 'offset')
+        ))
+
+        bundle = PatcherBundle(fields['bundle_id'])
+        parser.seek(fields['chunks_offset'])
+        for (chunk_id, compressed_size, uncompressed_size), in PatcherManifest._parse_table(parser, parse_chunklist):
             bundle.add_chunk(chunk_id, compressed_size, uncompressed_size)
-            parser.seek(pos + 4)
 
         return bundle
 
@@ -193,8 +197,6 @@ class PatcherManifest:
         (name, link, flag_ids, directory_id, filesize, chunk_ids)
         """
         fields = cls._parse_field_table(parser, (
-            None,
-            ('chunks', 'offset'),
             ('file_id', '<Q'),
             ('directory_id', '<Q'),
             ('file_size', '<L'),
@@ -202,7 +204,7 @@ class PatcherManifest:
             ('flags', '<Q'),
             None,
             None,
-            None,
+            ('chunks', 'offset'),
             None,
             ('link', 'str'),
             None,
@@ -228,8 +230,6 @@ class PatcherManifest:
         (name, directory_id, parent_id)
         """
         fields = cls._parse_field_table(parser, (
-            None,
-            None,
             ('directory_id', '<Q'),
             ('parent_id', '<Q'),
             ('name', 'str'),
@@ -243,6 +243,8 @@ class PatcherManifest:
         nfields = len(fields)
         output = {}
         parser.seek(fields_pos)
+        parser.skip(2) # vtable size
+        parser.skip(2) # object size
         for i, field, offset in zip(range(nfields), fields, parser.unpack(f'<{nfields}H')):
             if field is None:
                 continue
@@ -251,15 +253,14 @@ class PatcherManifest:
                 value = None
             else:
                 pos = entry_pos + offset
+                parser.seek(pos)
                 if fmt == 'offset':
-                    value = pos
+                    value = pos + parser.unpack('<l')[0]
                 elif fmt == 'str':
-                    parser.seek(pos)
                     value = parser.unpack('<l')[0]
                     parser.seek(pos + value)
                     value = parser.unpack_string()
                 else:
-                    parser.seek(pos)
                     value = parser.unpack(fmt)[0]
             output[name] = value
         return output
@@ -764,4 +765,3 @@ class MultiPatcherPatchElement(PatchElement):
     def paths(self, langs=True):
         pred = PatcherFile.langs_predicate(langs)
         return ((elem.extract_path(f), f.name.lower()) for elem, f in self.files if pred(f))
-


### PR DESCRIPTION
`_parse_bundle` ignored the vtable and assumed fixed, constant positions for the bunkdle_id and chunks_offset fields. That was incorrect and has worked because the format was consistent and hasn't been changed since.

However there's a new PBE patch with a manifest with different field positions, which broke the hardcoded offsets. I've refactored the code to use the `_parse_field_table` function which is the correct way of parsing the data and also fixed that function itself.

I haven't actually verified that everything is correct, but from what I tested at least most things should be ™️ 