### PR TITLE
Small update

### DIFF
--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -747,7 +747,7 @@ class GameHashGuesser(HashGuesser):
                 data = wad.read_file_data(f, wadfile)
                 if data is None:
                     continue
-                if wadfile.ext in ('bin', 'inibin'):
+                if wadfile.ext in ('bin', 'inibin', ''):
                     # bin files: find strings based on prefix, then parse the length
                     for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay|ClientStates)/', data):
                         i = m.start()

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -812,7 +812,7 @@ class GameHashGuesser(HashGuesser):
 
         # find path-like strings, then try to parse the length
         paths = set()
-        for m in re.finditer(br'(?:ASSETS|Common|DATA|DATA_SOON|DATA_Soon|Gameplay|Global|LEVELS|UX)/[0-9a-zA-Z_. /-]+', data):
+        for m in re.finditer(br'(?:ASSETS|Common|DATA|DATA_SOON|DATA_Soon|Gameplay|Global|LEVELS|Loadouts|UX)/[0-9a-zA-Z_. /-]+', data):
             path = m.group(0).lower().decode('ascii')
             paths.add(path.replace("data_soon/", "data/"))
             pos = m.start()

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -741,7 +741,7 @@ class GameHashGuesser(HashGuesser):
                 if wadfile.type == 2:
                     continue # softlink; contains no actual content
                 if wadfile.ext in ('dds', 'jpg', 'png', 'tga', 'ttf', 'otf', 'ogg', 'webm', 'anm',
-                                   'skl', 'skn', 'scb', 'sco', 'troybin', 'luabin', 'luabin64', 'bnk', 'wpk'):
+                                   'skl', 'skn', 'scb', 'sco', 'troybin', 'bnk', 'wpk', 'tex'):
                     continue # don't grep filetypes known to not contain full paths
 
                 data = wad.read_file_data(f, wadfile)

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -749,7 +749,7 @@ class GameHashGuesser(HashGuesser):
                     continue
                 if wadfile.ext in ('bin', 'inibin'):
                     # bin files: find strings based on prefix, then parse the length
-                    for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay)/', data):
+                    for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay|ClientStates)/', data):
                         i = m.start()
                         n = data[i-2] + (data[i-1] << 8)
                         try:
@@ -768,6 +768,9 @@ class GameHashGuesser(HashGuesser):
                         elif path.startswith('maps'):
                             self.check(f"data/{path}.mapgeo")
                             self.check(f"data/{path}.materials.bin")
+                        elif path.startswith('clientstates'):
+                            self.check(path.rsplit('/', 1)[0])
+                            self.check(path.rsplit('/', 2)[0])
                         else:
                             self.check(path)
                             if path.endswith(".png"):

--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -606,6 +606,8 @@ class GameHashGuesser(HashGuesser):
         re_suffix = re.compile(r'^(.*?)(\.[^.]+)?(\.[^.]+)$')
         for p in self.known.values():
             m = re_suffix.search(p)
+            if not m:
+                continue
             prefix, suffix, ext = m.groups()
             if suffix:
                 suffixes.add(suffix)

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -229,7 +229,7 @@ class Wad:
         for wadfile in self.files:
             if wadfile.path_hash in hashes:
                 wadfile.path = hashes[wadfile.path_hash]
-                wadfile.ext = wadfile.path.rsplit('.', 1)[1]
+                wadfile.ext = os.path.splitext(wadfile.path)[1][1:]
 
     def load_subchunk_toc(self):
         """Find subchunk TOC if available and parse it"""


### PR DESCRIPTION
Two small changes:
- a0c02140cc43336a80b1c2cf59d53256f108f908: I've found hashes by letting `.luabin` files get checked, so they shouldn't be included in the list. Also, luabin files are really tiny, so this does not affect speed negatively in any noticeable way. Additonally, I've added `.tex` files to be skipped as they are just texture files and won't contain paths (and the game does contain a decent amount of `.tex` files at this point).
- 0e226eb30ecc943a1a9c48d47864046203575350: This code path threw an exception when a resolved path for a wad hash did not contain an extension. This hadn't been an issue so far because all existing paths did have an extension, but with some new files' paths this throws. `os.path.splitext` seems to work fine as a replacement for the existing code as it returns an empty string in case of missing extension.