### PR TITLE
Guess extension for extensionless files and use when extracting

### DIFF
--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -749,7 +749,7 @@ class GameHashGuesser(HashGuesser):
                 data = wad.read_file_data(f, wadfile)
                 if data is None:
                     continue
-                if wadfile.ext in ('bin', 'inibin', ''):
+                if wadfile.ext in ('bin', 'inibin'):
                     # bin files: find strings based on prefix, then parse the length
                     for m in re.finditer(br'(?:ASSETS|DATA|Characters|Shaders|Maps/MapGeometry|Gameplay|ClientStates)/', data):
                         i = m.start()

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -250,7 +250,7 @@ class Wad:
         # avoid opening the file if not needed
         unknown_ext = True
         for wadfile in self.files:
-            if not wadfile.path and not wadfile.ext:
+            if not wadfile.ext:
                 wadfile.ext = _hash_to_guessed_extensions.get(wadfile.path_hash)
                 if not wadfile.ext:
                     unknown_ext = True
@@ -259,7 +259,7 @@ class Wad:
 
         with open(self.path, 'rb') as f:
             for wadfile in self.files:
-                if not wadfile.path and not wadfile.ext:
+                if not wadfile.ext:
                     data = self.read_file_data(f, wadfile)
                     if not data:
                         continue
@@ -277,15 +277,20 @@ class Wad:
                     wadfile.path = f"{path}/{wadfile.path_hash:016x}"
 
     def sanitize_paths(self):
-        """Truncate files whose basename has a length of at least 255"""
+        """Sanitize paths for extract purposes; for example truncating files whose basename has a length of at least 255"""
 
         for wadfile in self.files:
             if wadfile.path:
                 path, filename = os.path.split(wadfile.path)
+                basename, ext = os.path.splitext(filename)
+                if wadfile.ext and not ext:
+                    # extension was guessed, but the resolved path has no extension
+                    # in this case, append the guessed extension with custom suffix
+                    wadfile.path = f"{wadfile.path}.cdtb.{wadfile.ext}"
+
                 if len(filename) < 255:
                     continue
 
-                basename, ext = os.path.splitext(filename)
                 wadfile.path = os.path.join(path, f"{basename[:255-17-len(ext)]}.{wadfile.path_hash:016x}{ext}")
 
     def extract(self, output, overwrite=True):
@@ -320,4 +325,3 @@ class Wad:
             return wadfile.read_data(fwad, self.subchunk_toc)
         except MalformedSubchunkError:
             return None
-

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -277,21 +277,20 @@ class Wad:
                     wadfile.path = f"{path}/{wadfile.path_hash:016x}"
 
     def sanitize_paths(self):
-        """Sanitize paths for extract purposes; for example truncating files whose basename has a length of at least 255"""
+        """Sanitize paths for extract purposes; for example truncating files whose basename has a length of at least 250"""
 
         for wadfile in self.files:
             if wadfile.path:
-                path, filename = os.path.split(wadfile.path)
-                basename, ext = os.path.splitext(filename)
+                ext = os.path.splitext(wadfile.path)[1]
                 if wadfile.ext and not ext:
                     # extension was guessed, but the resolved path has no extension
                     # in this case, append the guessed extension with custom suffix
-                    wadfile.path = f"{wadfile.path}.cdtb.{wadfile.ext}"
+                    ext = f".cdtb.{wadfile.ext}"
+                    wadfile.path += ext
 
-                if len(filename) < 255:
-                    continue
-
-                wadfile.path = os.path.join(path, f"{basename[:255-17-len(ext)]}.{wadfile.path_hash:016x}{ext}")
+                path, filename = os.path.split(wadfile.path)
+                if len(filename) >= 250:
+                    wadfile.path = os.path.join(path, f"{filename[:250-17-len(ext)]}.{wadfile.path_hash:016x}{ext}")
 
     def extract(self, output, overwrite=True):
         """Extract WAD file


### PR DESCRIPTION
Code should be pretty self-explanatory. This should resolve potential conflicts with extensionless files and folders and also ensure those files are exported with a known good extension.

Ideally we should probably prefer the `guess_extension` method's return over a resolved path's extension, however this should be done in a way that doesn't require reading an entire wad file, potentially even multiple times, so that's for later.