### PR TITLE
Further fix extensionless file extracting

### DIFF
--- a/cdragontoolbox/hashes.py
+++ b/cdragontoolbox/hashes.py
@@ -812,7 +812,7 @@ class GameHashGuesser(HashGuesser):
 
         # find path-like strings, then try to parse the length
         paths = set()
-        for m in re.finditer(br'(?:ASSETS|Common|DATA|DATA_SOON|DATA_Soon|Gameplay|Global|LEVELS|Loadouts|UX)/[0-9a-zA-Z_. /-]+', data):
+        for m in re.finditer(br'(?:ASSETS|Common|DATA|DATA_SOON|DATA_Soon|Gameplay|Global|LEVELS|Loadouts|UX|UIAutoAtlas)/[0-9a-zA-Z_. /-]+', data):
             path = m.group(0).lower().decode('ascii')
             paths.add(path.replace("data_soon/", "data/"))
             pos = m.start()

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -306,8 +306,8 @@ class Wad:
 
         logger.info(f"extracting {self.path} to {output}")
 
-        self.set_unknown_paths("unknown")
         self.sanitize_paths()
+        self.set_unknown_paths("unknown")
 
         with open(self.path, 'rb') as fwad:
             for wadfile in self.files:

--- a/cdragontoolbox/wad.py
+++ b/cdragontoolbox/wad.py
@@ -282,10 +282,16 @@ class Wad:
         for wadfile in self.files:
             if wadfile.path:
                 ext = os.path.splitext(wadfile.path)[1]
-                if wadfile.ext and not ext:
-                    # extension was guessed, but the resolved path has no extension
-                    # in this case, append the guessed extension with custom suffix
-                    ext = f".cdtb.{wadfile.ext}"
+                if not ext:
+                    # some extensionless files conflict with folder names
+                    # append a custom suffix to resolve this conflict
+                    ext = ".cdtb"
+
+                    if wadfile.ext:
+                        # extension was guessed, but the resolved path has no extension
+                        # in this case, append the guessed extension
+                        ext += f".{wadfile.ext}"
+
                     wadfile.path += ext
 
                 path, filename = os.path.split(wadfile.path)


### PR DESCRIPTION
Lots more file/folder name conflicts popped up on 13.12 pbe, this time with files that weren't caught by the existing logic, as they aren't actually bin files and didn't trigger the condition (for example `clientstates/gameplay/ux/tft/tftunitshop` in `UI.wad.client`).

Those files will now be extracted with `.cdtb` extension instead of extensionless, as I don't see a better way to unconditionally resolve those conflicts.

Extensionless files that are in bin format for example will still be extracted as `original/path.cdtb.bin`.