### PR TITLE
speedup bin json dumping

### DIFF
--- a/cdragontoolbox/__main__.py
+++ b/cdragontoolbox/__main__.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import argparse
-import rapidjson
 import textwrap
 import fnmatch
 import logging
@@ -24,6 +23,7 @@ from cdragontoolbox.hashes import (
     LcuHashGuesser,
     GameHashGuesser,
 )
+from cdragontoolbox.tools import json_dump
 
 
 def parse_component_arg(parser, storage: Storage, component: str):
@@ -308,7 +308,7 @@ def command_bin_dump(parser, args):
     with open(args.bin, 'rb') as f:
         binfile = BinFile(f, btype_version=parsed_version)
     if args.json:
-        rapidjson.dump(binfile.to_serializable(), sys.stdout, mapping_mode=rapidjson.MM_COERCE_KEYS_TO_STRINGS)
+        json_dump(binfile.to_serializable(), sys.stdout)
     else:
         for entry in binfile.entries:
             print(entry)

--- a/cdragontoolbox/__main__.py
+++ b/cdragontoolbox/__main__.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import argparse
-import json
+import rapidjson
 import textwrap
 import fnmatch
 import logging
@@ -308,7 +308,7 @@ def command_bin_dump(parser, args):
     with open(args.bin, 'rb') as f:
         binfile = BinFile(f, btype_version=parsed_version)
     if args.json:
-        json.dump(binfile.to_serializable(), sys.stdout)
+        rapidjson.dump(binfile.to_serializable(), sys.stdout, mapping_mode=rapidjson.MM_COERCE_KEYS_TO_STRINGS)
     else:
         for entry in binfile.entries:
             print(entry)

--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -1,7 +1,5 @@
 import os
 import errno
-import json
-import rapidjson
 import re
 import shutil
 import struct
@@ -17,6 +15,7 @@ from .rstfile import hashfile_rst, RstFile, key_to_hash as key_to_rsthash
 from .tools import (
     write_file_or_remove,
     write_dir_or_remove,
+    json_dumps
 )
 
 logger = logging.getLogger(__name__)
@@ -711,7 +710,7 @@ class BinConverter(FileConverter):
                 binfile = BinFile(output_path, btype_version=self.btype_version)
             except ValueError as e:
                 raise FileConversionError(f"failed to parse bin file: {e}")
-            fout.write(rapidjson.dumps(binfile.to_serializable(), mapping_mode=rapidjson.MM_COERCE_KEYS_TO_STRINGS).encode('ascii'))
+            fout.write(json_dumps(binfile.to_serializable()).encode('ascii'))
 
 class SknConverter(FileConverter):
     def __init__(self):
@@ -765,4 +764,4 @@ class RstConverter(FileConverter):
             rst_json["entries"][key] = value
 
         with write_file_or_remove(output_path + '.json', False) as fout:
-            fout.write(json.dumps(rst_json, ensure_ascii=False))
+            fout.write(json_dumps(rst_json, ensure_ascii=False))

--- a/cdragontoolbox/export.py
+++ b/cdragontoolbox/export.py
@@ -1,6 +1,7 @@
 import os
 import errno
 import json
+import rapidjson
 import re
 import shutil
 import struct
@@ -710,7 +711,7 @@ class BinConverter(FileConverter):
                 binfile = BinFile(output_path, btype_version=self.btype_version)
             except ValueError as e:
                 raise FileConversionError(f"failed to parse bin file: {e}")
-            fout.write(json.dumps(binfile.to_serializable()).encode('ascii'))
+            fout.write(rapidjson.dumps(binfile.to_serializable(), mapping_mode=rapidjson.MM_COERCE_KEYS_TO_STRINGS).encode('ascii'))
 
 class SknConverter(FileConverter):
     def __init__(self):

--- a/cdragontoolbox/tools.py
+++ b/cdragontoolbox/tools.py
@@ -5,6 +5,16 @@ from contextlib import contextmanager
 
 import pyzstd
 zstd_decompress = pyzstd.decompress
+try:
+    import ujson
+    def json_dump(obj, fp, **kwargs):
+        return ujson.dump(obj, fp, **kwargs, escape_forward_slashes=False)
+    def json_dumps(obj, **kwargs):
+        return ujson.dumps(obj, **kwargs, escape_forward_slashes=False)
+except ImportError:
+    import json
+    json_dump = json.dump
+    json_dumps = json.dumps
 
 
 @contextmanager
@@ -68,4 +78,3 @@ class BinaryParser:
     def unpack_string(self):
         """Unpack string prefixed by its 32-bit length"""
         return self.f.read(self.unpack('<L')[0]).decode('utf-8')
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ hachoir
 xxhash
 pyzstd
 Pillow
+python-rapidjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ hachoir
 xxhash
 pyzstd
 Pillow
-python-rapidjson
+ujson


### PR DESCRIPTION
A large part of the dumping process was spent in the actual json dumping code, so it gives a significant speedup here to use a faster json library than the default one.
This adds the requirement of `python-rapidjson`, which is more or less a drop-in replacement for `json`, but has some slight differences in behavior (see [incompatibilities](https://python-rapidjson.readthedocs.io/en/latest/quickstart.html#incompatibilities)), so I didn't just replace all json calls with it.

When testing with the `data/maps/shipping/map30/map30.bin`, using this changeset improves dumping speed from ~9.3s to ~7.6s for me.