### PR TITLE
Remove disabled augments from arena json

### DIFF
--- a/cdragontoolbox/arenadata.py
+++ b/cdragontoolbox/arenadata.py
@@ -76,7 +76,8 @@ class ArenaTransformer:
 
         augments = []
         for augment in augment_entries:
-
+            if augment.getv("enabled", True) == False:
+                continue
             augment_datavalues = {}
             augment_calculations = {}
             augment_spellobject = augment.getv(0x1418F849)

--- a/cdragontoolbox/arenadata.py
+++ b/cdragontoolbox/arenadata.py
@@ -76,7 +76,7 @@ class ArenaTransformer:
 
         augments = []
         for augment in augment_entries:
-            if augment.getv("enabled", True) == False:
+            if not augment.getv("enabled", True):
                 continue
             augment_datavalues = {}
             augment_calculations = {}


### PR DESCRIPTION
Riot has decided to include disabled augments in their data with duplicated ids. 

Because of this we need to filter out disabled augments so that we have an accurate dataset.