### PR TITLE
add export option for atlas info files

### DIFF
--- a/cdtb/arenadata.py
+++ b/cdtb/arenadata.py
@@ -2,7 +2,7 @@ import os
 import copy
 from .binfile import BinFile
 from .rstfile import RstFile
-from .tools import json_dump, stringtable_paths
+from .tools import convert_cdragon_path, json_dump, stringtable_paths
 
 
 class ArenaTransformer:
@@ -85,9 +85,6 @@ class ArenaTransformer:
             })
 
         return augments
-
-def convert_cdragon_path(path):
-    return path.lower().replace(".dds", ".png").replace(".tex", ".png")
 
 def main():
     import argparse

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -435,10 +435,10 @@ class CdragonRawPatchExporter:
         exporter.converters = [
             ImageConverter(('.dds', '.tga')),
             TexConverter(),
+            AtlasInfoConverter(re.compile(r'game/clientstates/.*\.cdtb$|assets/items/icons2d/autoatlas/.*/atlas_info\.bin$')),
             BinConverter(re.compile(r'game/.*\.bin$'), btype_version),
             SknConverter(),
             RstConverter(re.compile(r'game/.*/menu/.*\.(txt|stringtable)$')),
-            AtlasInfoConverter(re.compile(r'game/clientstates/.*\.cdtb$')),
         ]
         exporter.add_patch_files(patch)
         return exporter

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -812,8 +812,8 @@ class AtlasInfoConverter(FileConverter):
 
         texture_count, = parser.unpack("<L")
         for _ in range(texture_count):
-            texture_path = parser.unpack_string()
+            texture_name = parser.unpack_string()
             startX, startY, endX, endY, atlas_index = parser.unpack("<ffffL")
-            atlas_info[atlas_paths[atlas_index]][texture_path] = {"startX": startX, "startY": startY, "endX": endX, "endY": endY}
+            atlas_info[atlas_paths[atlas_index]][texture_name] = {"startX": startX, "startY": startY, "endX": endX, "endY": endY}
 
         return atlas_info

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -437,7 +437,7 @@ class CdragonRawPatchExporter:
             BinConverter(re.compile(r'game/.*\.bin$'), btype_version),
             SknConverter(),
             RstConverter(re.compile(r'game/.*/menu/.*\.(txt|stringtable)$')),
-            AtlasInfoConverter(re.compile(r'game/clientstates/.*\.cdtb$'))
+            AtlasInfoConverter(re.compile(r'game/clientstates/.*\.cdtb$')),
         ]
         exporter.add_patch_files(patch)
         return exporter
@@ -806,14 +806,9 @@ class AtlasInfoConverter(FileConverter):
     def parse_atlasinfo(f):
         parser = BinaryParser(f)
 
-        atlas_info = {}
         atlas_count, = parser.unpack("<L")
-        atlas_paths = [None] * atlas_count
-
-        for i in range(atlas_count):
-            atlas_path = parser.unpack_string()
-            atlas_paths[i] = atlas_path
-            atlas_info[atlas_path] = {}
+        atlas_paths = [parser.unpack_string() for _ in range(atlas_count)]
+        atlas_info = {atlas_path: {} for atlas_path in atlas_paths}
 
         texture_count, = parser.unpack("<L")
         for _ in range(texture_count):

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -14,6 +14,7 @@ from .sknfile import SknFile
 from .rstfile import hashfile_rst, RstFile, key_to_hash as key_to_rsthash
 from .tools import (
     BinaryParser,
+    convert_cdragon_path,
     json_dump,
     write_file_or_remove,
     write_dir_or_remove,
@@ -807,13 +808,13 @@ class AtlasInfoConverter(FileConverter):
         parser = BinaryParser(f)
 
         atlas_count, = parser.unpack("<L")
-        atlas_paths = [parser.unpack_string() for _ in range(atlas_count)]
-        atlas_info = {atlas_path: {} for atlas_path in atlas_paths}
+        atlas_paths = [convert_cdragon_path(parser.unpack_string()) for _ in range(atlas_count)]
+        atlas_info = {}
 
         texture_count, = parser.unpack("<L")
         for _ in range(texture_count):
             texture_name = parser.unpack_string()
             startX, startY, endX, endY, atlas_index = parser.unpack("<ffffL")
-            atlas_info[atlas_paths[atlas_index]][texture_name] = {"startX": startX, "startY": startY, "endX": endX, "endY": endY}
+            atlas_info[texture_name] = {"atlasPath": atlas_paths[atlas_index], "startX": startX, "startY": startY, "endX": endX, "endY": endY}
 
         return atlas_info

--- a/cdtb/tools.py
+++ b/cdtb/tools.py
@@ -101,3 +101,9 @@ def stringtable_paths(base_dir):
         return {re.search(r"fontconfig_(.._..)\.txt$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt"))}
     else:
         raise RuntimeError("cannot find stringtable files")
+
+def convert_cdragon_path(path):
+    path, ext = os.path.splitext(path.lower())
+    if ext == ".dds" or ext == ".tex":
+        ext = ".png"
+    return path + ext


### PR DESCRIPTION
Converts `clientstates/*.cdtb` files to a json-format including all relevant information.
Those files are used to index atlas dds files, contained is information about all the atlas's subimages.

Example file `clientstates/gameplay/ux/endofgame.cdtb` gets converted to:
```json
{
    "UIAutoAtlas/ClientStates/Gameplay/UX/EndOfGame/atlas_0.dds": {
        "ASSETS/UX/TFTMobile/Modal/TFTM_Modal_ContinueShroud.TFTmT1318.png": {
            "startX": 0.00390625,
            "startY": 0.015625,
            "endX": 0.853515625,
            "endY": 0.5703125
        }
    }
}
```

Open to suggestions about naming and stuff. This also will require basic testing to make sure all files parse cleanly.
