### PR TITLE
Support new stringtable path

### DIFF
--- a/cdtb/arenadata.py
+++ b/cdtb/arenadata.py
@@ -1,10 +1,9 @@
 import json
-import glob
 import os
 import copy
-import re
 from .binfile import BinFile, BinHashBase
 from .rstfile import RstFile
+from .tools import stringtable_paths
 
 
 class NaiveJsonEncoder(json.JSONEncoder):
@@ -39,24 +38,16 @@ class ArenaTransformer:
         Otherwise, export for given `xx_yy` language codes.
         """
 
-        stringtable_dir = os.path.join(self.input_dir, "data/menu")
-        stringtable_glob = "main_??_??.stringtable"
-        stringtable_format = "main_%s.stringtable"
-        stringtable_regex = r"main_(.._..)\.stringtable$"
-
+        stringtables = stringtable_paths(self.input_dir)
         if langs is None:
-            langs = []
-            for path in glob.glob(os.path.join(stringtable_dir, stringtable_glob)):
-                m = re.search(stringtable_regex, path)
-                if m:
-                    langs.append(m.group(1))
+            langs = list(stringtables)
 
         os.makedirs(output, exist_ok=True)
 
         template = self.build_template()
         for lang in langs:
             instance = copy.deepcopy(template)
-            replacements = RstFile(os.path.join(stringtable_dir, stringtable_format % lang))
+            replacements = RstFile(stringtables[lang])
 
             def replace_in_data(entry):
                 for key in ("name", "desc", "tooltip"):

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -434,7 +434,7 @@ class CdragonRawPatchExporter:
             TexConverter(),
             BinConverter(re.compile(r'game/.*\.bin$'), btype_version),
             SknConverter(),
-            RstConverter(re.compile(r'game/data/menu/.*\.(txt|stringtable)$'))
+            RstConverter(re.compile(r'game/.*/menu/.*\.(txt|stringtable)$'))
         ]
         exporter.add_patch_files(patch)
         return exporter

--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -1,10 +1,9 @@
 import json
-import glob
 import os
 import copy
-import re
 from .binfile import BinFile, BinHashBase, BinEmbedded
 from .rstfile import RstFile
+from .tools import stringtable_paths
 
 
 class NaiveJsonEncoder(json.JSONEncoder):
@@ -62,31 +61,17 @@ class TftTransformer:
         Otherwise, export for given `xx_yy` language codes.
         """
 
-        stringtable_dir = os.path.join(self.input_dir, "data/menu")
-        # Support both 'font_config_*.txt' (old) and 'main_*.stringtable' (new)
-        if os.path.exists(os.path.join(stringtable_dir, "fontconfig_en_us.txt")):
-            stringtable_glob = "fontconfig_??_??.txt"
-            stringtable_format = "fontconfig_%s.txt"
-            stringtable_regex = r"fontconfig_(.._..)\.txt$"
-        else:
-            stringtable_glob = "main_??_??.stringtable"
-            stringtable_format = "main_%s.stringtable"
-            stringtable_regex = r"main_(.._..)\.stringtable$"
-
+        stringtables = stringtable_paths(self.input_dir)
 
         if langs is None:
-            langs = []
-            for path in glob.glob(os.path.join(stringtable_dir, stringtable_glob)):
-                m = re.search(stringtable_regex, path)
-                if m:
-                    langs.append(m.group(1))
+            langs = list(stringtables)
 
         os.makedirs(output, exist_ok=True)
 
         template = self.build_template()
         for lang in langs:
             instance = copy.deepcopy(template)
-            replacements = load_translations(os.path.join(stringtable_dir, stringtable_format % lang))
+            replacements = load_translations(stringtables[lang])
 
             def replace_in_data(entry):
                 for key in ("name", "desc"):


### PR DESCRIPTION
This is currently pbe-only and also currently only `en_us/main.stringtable` actually exists, but PRing this early for visibility and feedback.

This could technically be merged before the current PBE paths hit live as the code now handles all 3 known path variations.