### PR TITLE
Export language-specific files to their own subfolder

### DIFF
--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -476,9 +476,13 @@ class CdragonRawPatchExporter:
 
         for path, wad in exporter.wads.items():
             if path.endswith('.wad.client'):
+                if lang_match := re.search(r"\.(.._..)\.wad\.client$", path):
+                    subdir = f"game/{lang_match.group(1).lower()}"
+                else:
+                    subdir = "game"
                 wad.files = [wf for wf in wad.files if filter_path(wf.path)]
                 for wf in wad.files:
-                    wf.path = f"game/{wf.path}"
+                    wf.path = f"{subdir}/{wf.path}"
         # remove emptied WADs
         for path, wad in list(exporter.wads.items()):
             if not wad.files:

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -439,8 +439,7 @@ class CdragonRawPatchExporter:
         exporter.add_patch_files(patch)
         return exporter
 
-    @staticmethod
-    def _transform_exported_files(exporter):
+    def _transform_exported_files(self, exporter):
         """Filter exported files, resolve unknowns, etc."""
 
         # resolve unknowns paths
@@ -476,10 +475,12 @@ class CdragonRawPatchExporter:
 
         for path, wad in exporter.wads.items():
             if path.endswith('.wad.client'):
-                if lang_match := re.search(r"\.(.._..)\.wad\.client$", path):
-                    subdir = f"game/{lang_match.group(1).lower()}"
-                else:
-                    subdir = "game"
+                subdir = "game"
+                # Export language-specific files to a dedicated subdir to avoid conflicts
+                # Don't do it for patches prior 14.4, to avoid breaking URLs, and possibly our own code
+                if self.patch.version == "main" or self.patch.version >= PatchVersion("14.4"):
+                    if lang_match := re.search(r"\.(.._..)\.wad\.client$", path):
+                        subdir = f"game/{lang_match.group(1).lower()}"
                 wad.files = [wf for wf in wad.files if filter_path(wf.path)]
                 for wf in wad.files:
                     wf.path = f"{subdir}/{wf.path}"


### PR DESCRIPTION
This is mostly untested, but should work I think.

Background is that riot has renamed most language-specific files inside wads, like VO audio files, from containing their respective language's identifier (like `de_de`) to instead contain `en_us`. That means that all those files from different wads have the same name but contain different content. To avoid those conflicts while extracting language-specific files are not exported to a new folder for that language in `game/`.