### PR TITLE
fix storage default path

### DIFF
--- a/cdtb/storage.py
+++ b/cdtb/storage.py
@@ -153,7 +153,7 @@ def storage_conf_from_path(path):
         storage_type, storage_path = path.split(':', 1)
         return {'type': storage_type, 'path': storage_path}
     else:
-        return {'type': 'patcher', 'path': storage_path}
+        return {'type': 'patcher', 'path': path}
 
 def guess_storage_conf(path):
     """Try to guess storage configuration from path"""


### PR DESCRIPTION
When running the command from the readme: `python -m cdtb -v download -s cdn patch=`

I was getting the following error:

```python
Traceback (most recent call last):
  File "C:\Users\Rapha\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Rapha\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Rapha\AppData\Local\Programs\Python\Python310\Scripts\cdtb.exe\__main__.py", line 7, in <module>
  File "M:\dev\github_external\CDTB\cdtb\__main__.py", line 520, in main
    args.storage = parse_storage_args(parser, args)
  File "M:\dev\github_external\CDTB\cdtb\__main__.py", line 63, in parse_storage_args
    conf = storage_conf_from_path(path)
  File "M:\dev\github_external\CDTB\cdtb\storage.py", line 156, in storage_conf_from_path
    return {'type': 'patcher', 'path': storage_path}
UnboundLocalError: local variable 'storage_path' referenced before assignment
```

I fixed it by changing the variable used for the default path.

Thanks for your work!