### PR TITLE
Support new rst hash format (xxh3)

### DIFF
--- a/cdtb/__main__.py
+++ b/cdtb/__main__.py
@@ -319,7 +319,7 @@ def command_bin_dump(parser, args):
     if not os.path.isfile(args.bin):
         parser.error(f"BIN file not found: {args.bin}")
 
-    parsed_version = sum(int(num) * (100 ** i) for i, num in enumerate(reversed(args.patch_version.split('.'))))
+    parsed_version = PatchVersion(args.patch_version if args.patch_version else "main").as_int()
 
     with open(args.bin, 'rb') as f:
         binfile = BinFile(f, btype_version=parsed_version)
@@ -472,8 +472,8 @@ def create_parser():
                                       help="dump a BIN file as a text tree")
     subparser.add_argument('-j', '--json', action='store_true',
                            help="extract to JSON")
-    subparser.add_argument('-V', '--patch-version', default="10.8",
-                           help="patch version this BIN file belongs to (default: %(default)s)")
+    subparser.add_argument('-V', '--patch-version', default=None,
+                           help="patch version this BIN file belongs to in the format XX.YY (default: latest patch)")
     subparser.add_argument('bin',
                            help="BIN file to extract")
 

--- a/cdtb/arenadata.py
+++ b/cdtb/arenadata.py
@@ -6,8 +6,9 @@ from .tools import convert_cdragon_path, json_dump, stringtable_paths
 
 
 class ArenaTransformer:
-    def __init__(self, input_dir):
+    def __init__(self, input_dir, game_version=1415):
         self.input_dir = input_dir
+        self.rsthash_version = game_version
 
     def build_template(self):
         """Parse bin data into template data"""
@@ -37,7 +38,7 @@ class ArenaTransformer:
         template = self.build_template()
         for lang in langs:
             instance = copy.deepcopy(template)
-            replacements = RstFile(stringtables[lang])
+            replacements = RstFile(stringtables[lang], self.rsthash_version)
 
             def replace_in_data(entry):
                 for key in ("name", "desc", "tooltip"):
@@ -91,9 +92,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="directory with extracted bin files")
     parser.add_argument("-o", "--output", default="arena", help="output directory")
+    parser.add_argument('-V', '--patch-version', default="14.15",
+                           help="patch version the input files belong to (default: %(default)s)")
     args = parser.parse_args()
 
-    arena_transformer = ArenaTransformer(args.input)
+    parsed_version = sum(int(num) * (100 ** i) for i, num in enumerate(reversed(args.patch_version.split('.'))))
+
+    arena_transformer = ArenaTransformer(args.input, game_version=parsed_version)
     arena_transformer.export(args.output, langs=None)
 
 if __name__ == "__main__":

--- a/cdtb/arenadata.py
+++ b/cdtb/arenadata.py
@@ -1,5 +1,6 @@
 import os
 import copy
+from .storage import PatchVersion
 from .binfile import BinFile
 from .rstfile import RstFile
 from .tools import convert_cdragon_path, json_dump, stringtable_paths
@@ -92,11 +93,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="directory with extracted bin files")
     parser.add_argument("-o", "--output", default="arena", help="output directory")
-    parser.add_argument('-V', '--patch-version', default="14.15",
-                           help="patch version the input files belong to (default: %(default)s)")
+    parser.add_argument('-V', '--patch-version', default=None,
+                           help="patch version the input files belong to in the format XX.YY (default: latest patch)")
     args = parser.parse_args()
 
-    parsed_version = sum(int(num) * (100 ** i) for i, num in enumerate(reversed(args.patch_version.split('.'))))
+    parsed_version = PatchVersion(args.patch_version if args.patch_version else "main").as_int()
 
     arena_transformer = ArenaTransformer(args.input, game_version=parsed_version)
     arena_transformer.export(args.output, langs=None)

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -418,7 +418,7 @@ class CdragonRawPatchExporter:
         if self.patch.version != 'main' and self.patch.version < PatchVersion('9.14'):
             return  # no supported TFT data before 9.14
         # don't import in module to be able to execute tftdata module
-        game_version = int(self.patch.version)
+        game_version = self.patch.version.as_int()
         from .tftdata import TftTransformer
         transformer = TftTransformer(os.path.join(self.output, "game"), game_version)
         transformer.export(os.path.join(self.output, "cdragon/tft"), langs=None)
@@ -432,7 +432,7 @@ class CdragonRawPatchExporter:
         transformer.export(os.path.join(self.output, "cdragon/arena"), langs=None)
 
     def _create_exporter(self, patch):
-        game_version = int(patch.version)
+        game_version = patch.version.as_int()
         exporter = Exporter(self.output)
         exporter.converters = [
             ImageConverter(('.dds', '.tga')),

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -12,7 +12,7 @@ from .storage import PatchVersion
 from .wad import Wad
 from .binfile import BinFile
 from .sknfile import SknFile
-from .rstfile import RstFile, get_hashfile as get_rsthashfile, key_to_hash as key_to_rsthash
+from .rstfile import RstFile, get_hashfile as get_rsthashfile
 from .tools import (
     BinaryParser,
     convert_cdragon_path,
@@ -782,7 +782,7 @@ class RstConverter(FileConverter):
             shutil.copyfileobj(fin, fout)
 
         rstfile = RstFile(output_path, self.rsthash_version)
-        hashes = {key_to_rsthash(hash, rstfile.hash_bits): value for hash, value in self.hashes.items()}
+        hashes = {rstfile.truncate_hash(hash): value for hash, value in self.hashes.items()}
         rst_json = {"entries": {}, "version": rstfile.version}
         for key, value in rstfile.entries.items():
             if key in hashes:

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -12,7 +12,7 @@ from .storage import PatchVersion
 from .wad import Wad
 from .binfile import BinFile
 from .sknfile import SknFile
-from .rstfile import RstFile, get_hashfile as get_rsthashfile
+from .rstfile import RstFile, get_hashfile as get_rsthashfile, key_to_hash as key_to_rsthash
 from .tools import (
     BinaryParser,
     convert_cdragon_path,
@@ -782,7 +782,7 @@ class RstConverter(FileConverter):
             shutil.copyfileobj(fin, fout)
 
         rstfile = RstFile(output_path, self.rsthash_version)
-        hashes = {rstfile.truncate_hash(hash): value for hash, value in self.hashes.items()}
+        hashes = {key_to_rsthash(hash, bits=rstfile.hash_bits): value for hash, value in self.hashes.items()}
         rst_json = {"entries": {}, "version": rstfile.version}
         for key, value in rstfile.entries.items():
             if key in hashes:

--- a/cdtb/rstfile.py
+++ b/cdtb/rstfile.py
@@ -1,24 +1,34 @@
 import os
-from xxhash import xxh64_intdigest
+from xxhash import xxh3_64_intdigest, xxh64_intdigest
 from base64 import b64encode
 from .tools import BinaryParser
 from .hashes import HashFile, default_hash_dir
 
 
-def key_to_hash(key, bits=40):
+def key_to_hash(key, bits=40, rsthash_version=1415):
     if isinstance(key, str):
-        key = xxh64_intdigest(key.lower())
+        if rsthash_version >= 1415:
+            key = xxh3_64_intdigest(key.lower())
+        else:
+            key = xxh64_intdigest(key.lower())
     return key & ((1 << bits) - 1)
 
+def get_hashfile(game_version=1415):
+    if game_version >= 1415:
+        return hashfile_rst_new
+    else:
+        return hashfile_rst
 
 hashfile_rst = HashFile(default_hash_dir / "hashes.rst.txt", hash_size=10)
+hashfile_rst_new = HashFile(default_hash_dir / "hashes.rstnew.txt", hash_size=10)
 
 class RstFile:
-    def __init__(self, path_or_f=None):
+    def __init__(self, path_or_f=None, rsthash_version=1415):
         self.font_config = None
         self.entries = {}
         self.hash_bits = 40
         self.version = None
+        self.rsthash_version = rsthash_version
 
         if path_or_f is not None:
             if isinstance(path_or_f, str):
@@ -29,14 +39,14 @@ class RstFile:
 
     def __getitem__(self, key):
         try:
-            h = key_to_hash(key, self.hash_bits)
+            h = key_to_hash(key, self.hash_bits, self.rsthash_version)
             return self.entries[h]
         except (TypeError, KeyError):
             raise KeyError(key)
 
     def __contains__(self, key):
         try:
-            h = key_to_hash(key, self.hash_bits)
+            h = key_to_hash(key, self.hash_bits, self.rsthash_version)
             return h in self.entries
         except TypeError:
             return False

--- a/cdtb/rstfile.py
+++ b/cdtb/rstfile.py
@@ -19,8 +19,8 @@ def key_to_hash(key, bits=64, rsthash_version=1415):
     return key & ((1 << bits) - 1)
 
 
-hashfile_rst_xxh64 = HashFile(default_hash_dir / "hashes.rst.xxh64.txt", hash_size=10)
-hashfile_rst_xxh3 = HashFile(default_hash_dir / "hashes.rst.xxh3.txt", hash_size=10)
+hashfile_rst_xxh64 = HashFile(default_hash_dir / "hashes.rst.xxh64.txt", hash_size=16)
+hashfile_rst_xxh3 = HashFile(default_hash_dir / "hashes.rst.xxh3.txt", hash_size=16)
 
 class RstFile:
     def __init__(self, path_or_f=None, game_version=1415):

--- a/cdtb/storage.py
+++ b/cdtb/storage.py
@@ -88,7 +88,7 @@ class PatchVersion(BaseVersion):
                 self.s = '.'.join(str(x) for x in self.t)
             assert len(self.t) == 2, "invalid patch version format"
 
-    def __int__(self):
+    def as_int(self):
         if self.t == "main":
             return 9999 # return highest possible number
         else:
@@ -477,4 +477,3 @@ def parse_storage_component(storage: Storage, component: str) -> Union[None, Pat
         return patch
     else:
         return storage.patch_element(name, version, stored=version is not None)
-

--- a/cdtb/storage.py
+++ b/cdtb/storage.py
@@ -88,6 +88,12 @@ class PatchVersion(BaseVersion):
                 self.s = '.'.join(str(x) for x in self.t)
             assert len(self.t) == 2, "invalid patch version format"
 
+    def __int__(self):
+        if self.t == "main":
+            return 9999 # return highest possible number
+        else:
+            v0, v1 = self.t
+            return v0 * 100 + v1
 
 class RequestStreamReader:
     """Wrapper for reading data from stream request"""

--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -1,5 +1,6 @@
 import os
 import copy
+from .storage import PatchVersion
 from .binfile import BinFile, BinEmbedded
 from .rstfile import RstFile
 from .tools import json_dump, stringtable_paths
@@ -346,11 +347,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="directory with extracted bin files")
     parser.add_argument("-o", "--output", default="tft", help="output directory")
-    parser.add_argument('-V', '--patch-version', default="14.15",
-                           help="patch version the input files belong to (default: %(default)s)")
+    parser.add_argument('-V', '--patch-version', default=None,
+                           help="patch version the input files belong to in the format XX.YY (default: latest patch)")
     args = parser.parse_args()
 
-    parsed_version = sum(int(num) * (100 ** i) for i, num in enumerate(reversed(args.patch_version.split('.'))))
+    parsed_version = PatchVersion(args.patch_version if args.patch_version else "main").as_int()
 
     tft_transformer = TftTransformer(args.input, game_version=parsed_version)
     tft_transformer.export(args.output, langs=None)

--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -5,11 +5,11 @@ from .rstfile import RstFile
 from .tools import json_dump, stringtable_paths
 
 
-def load_translations(path):
+def load_translations(path, rsthash_version=1415):
     with open(path, "rb") as f:
         if f.read(3) == b"RST":
             f.seek(0)
-            return RstFile(f)
+            return RstFile(f, rsthash_version)
         else:
             translations = {}
             for line in f:
@@ -23,8 +23,9 @@ def load_translations(path):
 
 
 class TftTransformer:
-    def __init__(self, input_dir):
+    def __init__(self, input_dir, game_version=1415):
         self.input_dir = input_dir
+        self.rsthash_version = game_version
 
     def build_template(self):
         """Parse bin data into template data"""
@@ -62,7 +63,7 @@ class TftTransformer:
         template = self.build_template()
         for lang in langs:
             instance = copy.deepcopy(template)
-            replacements = load_translations(stringtables[lang])
+            replacements = load_translations(stringtables[lang], self.rsthash_version)
 
             def replace_in_data(entry):
                 for key in ("name", "desc"):
@@ -345,9 +346,13 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="directory with extracted bin files")
     parser.add_argument("-o", "--output", default="tft", help="output directory")
+    parser.add_argument('-V', '--patch-version', default="14.15",
+                           help="patch version the input files belong to (default: %(default)s)")
     args = parser.parse_args()
 
-    tft_transformer = TftTransformer(args.input)
+    parsed_version = sum(int(num) * (100 ** i) for i, num in enumerate(reversed(args.patch_version.split('.'))))
+
+    tft_transformer = TftTransformer(args.input, game_version=parsed_version)
     tft_transformer.export(args.output, langs=None)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Starting with pbe patch 14.15, rst hashes now use xxh3 instead of xxh64.

I've modified the code in a similar way to the existing bin type handling, as sadly riot did not care to update the rst file version to signal the updated hashing method.

Main TODO: Decide how to handle hashes.

Currently my idea is to have a legacy hashfile containing xxh64 hashes and a new hashfile containing xxh3 hashes. That allows for backwards compatibility in parsing and converting stringtable files from before patch 14.15 using that legacy hashfile.
Current names are temporary; not entirely sure how to name them.
some ideas:
`hashes.rstlegacy.txt` - `hashes.rst.txt`
`hashes.rst.xxh64.txt` - `hashes.rst.xxh3.txt`