### PR TITLE
Regex fix for new tft stringtables

### DIFF
--- a/cdtb/tools.py
+++ b/cdtb/tools.py
@@ -98,11 +98,11 @@ def stringtable_paths(base_dir, game):
     if os.path.exists(os.path.join(base_dir, f"en_us/data/menu/en_us/{game}.stringtable")):
         return {re.search(rf"(.._..)/data/menu/en_us/{game}.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, f"??_??/data/menu/en_us/{game}.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "en_us/data/menu/en_us/main.stringtable")):
-        return {re.search(r"(.._..)/data/menu/en_us/main.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "??_??/data/menu/en_us/main.stringtable"))}
+        return {re.search(r"(.._..)/data/menu/en_us/main.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, "??_??/data/menu/en_us/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/main_en_us.stringtable")):
-        return {re.search(r"main_(.._..)\.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/main_??_??.stringtable"))}
+        return {re.search(r"main_(.._..)\.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/main_??_??.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt")):
-        return {re.search(r"fontconfig_(.._..)\.txt$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt"))}
+        return {re.search(r"fontconfig_(.._..)\.txt$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt"))}
     else:
         raise RuntimeError("cannot find stringtable files")
 

--- a/cdtb/tools.py
+++ b/cdtb/tools.py
@@ -97,6 +97,8 @@ def stringtable_paths(base_dir):
         return {re.search(r"(.._..)/data/menu/en_us/main.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "??_??/data/menu/en_us/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/main_en_us.stringtable")):
         return {re.search(r"main_(.._..)\.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/main_??_??.stringtable"))}
+    if os.path.exists(os.path.join(base_dir, "data/menu/en_us/main.stringtable")):
+        return {re.search(r"data/menu\\(.._..)\\main.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/??_??/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt")):
         return {re.search(r"fontconfig_(.._..)\.txt$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt"))}
     else:

--- a/cdtb/tools.py
+++ b/cdtb/tools.py
@@ -96,7 +96,7 @@ def stringtable_paths(base_dir, game):
 
     # Find the current format; assume 'en_us' language is always available
     if os.path.exists(os.path.join(base_dir, f"en_us/data/menu/en_us/{game}.stringtable")):
-        return {re.search(rf"(.._..)/data/menu/en_us/{game}.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, f"??_??/data/menu/en_us/{game}.stringtable"))}
+        return {re.search(f"(.._..)/data/menu/en_us/{game}.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, f"??_??/data/menu/en_us/{game}.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "en_us/data/menu/en_us/main.stringtable")):
         return {re.search(r"(.._..)/data/menu/en_us/main.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, "??_??/data/menu/en_us/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/main_en_us.stringtable")):

--- a/cdtb/tools.py
+++ b/cdtb/tools.py
@@ -96,13 +96,11 @@ def stringtable_paths(base_dir, game):
 
     # Find the current format; assume 'en_us' language is always available
     if os.path.exists(os.path.join(base_dir, f"en_us/data/menu/en_us/{game}.stringtable")):
-        return {re.search(f"(.._..)/data/menu/en_us/{game}.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, f"??_??/data/menu/en_us/{game}.stringtable"))}
+        return {re.search(rf"(.._..)/data/menu/en_us/{game}.stringtable$", path.replace('\\', '/')).group(1): path for path in glob.glob(os.path.join(base_dir, f"??_??/data/menu/en_us/{game}.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "en_us/data/menu/en_us/main.stringtable")):
         return {re.search(r"(.._..)/data/menu/en_us/main.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "??_??/data/menu/en_us/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/main_en_us.stringtable")):
         return {re.search(r"main_(.._..)\.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/main_??_??.stringtable"))}
-    if os.path.exists(os.path.join(base_dir, "data/menu/en_us/main.stringtable")):
-        return {re.search(r"data/menu\\(.._..)\\main.stringtable$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/??_??/main.stringtable"))}
     elif os.path.exists(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt")):
         return {re.search(r"fontconfig_(.._..)\.txt$", path).group(1): path for path in glob.glob(os.path.join(base_dir, "data/menu/fontconfig_??_??.txt"))}
     else:


### PR DESCRIPTION
Correcting a slight issue in regex search for the stringtable paths, resulting in no valid stringtable lookups for the TFT data files

Also replaced `\\` with `/` in paths from glob.glob (think this is only necessary as I'm running on windows, happy to remove it if you want)

Would be great to re-run the TFT data with these changes in place