### PR TITLE
Lint and cleanup

### DIFF
--- a/cdtb/__init__.py
+++ b/cdtb/__init__.py
@@ -1,20 +1,2 @@
 import logging
 logger = logging.getLogger(__name__)
-
-from cdtb.storage import (
-    Storage,
-    Patch,
-    PatchElement,
-)
-from cdtb.wad import (
-    Wad,
-)
-from cdtb.export import (
-    Exporter,
-    CdragonRawPatchExporter,
-)
-
-# import storages to register them
-import cdtb.rads
-import cdtb.patcher
-

--- a/cdtb/__main__.py
+++ b/cdtb/__main__.py
@@ -14,7 +14,6 @@ from cdtb.storage import (
     parse_storage_component,
     storage_conf_from_path,
 )
-from cdtb.patcher import PatcherStorage
 from cdtb.wad import Wad
 from cdtb.export import CdragonRawPatchExporter
 from cdtb.binfile import BinFile

--- a/cdtb/export.py
+++ b/cdtb/export.py
@@ -162,36 +162,6 @@ class Exporter:
             for src, dst in elem.paths(langs=True):
                 self.add_path(src, dst)
 
-    def filter_path(self, source_path, export_path):
-        """Remove files that are in the provided path
-
-        Paths have the same meaning as for add_path().
-
-        WAD files are first compared by source path, then by file's sha256.
-        Plain files are simply removed.
-        """
-
-        if export_path in self.plain_files:
-            del self.plain_files[export_path]
-        elif source_path.endswith('.wad') or source_path.endswith('.wad.client'):
-            self_wad = self.wads.get(export_path)
-            if self_wad is None:
-                return  # not exported
-            if self_wad.path == source_path:
-                # same path: WADs are identical
-                logger.debug(f"filter identical WAD file: {source_path}")
-                del self.wads[export_path]
-            else:
-                # compare the sha256 hashes to find the common files
-                # don't resolve hashes: we just need the sha256
-                logger.debug(f"filter modified WAD file: {source_path}")
-                other_wad = Wad(source_path, hashes={})
-                other_sha256 = {wf.path_hash: wf.sha256 for wf in other_wad.files}
-                # change the files from the wad so it only extract these
-                self_wad.files = [wf for wf in self_wad.files if wf.sha256 != other_sha256.get(wf.path_hash)]
-                if not self_wad.files:
-                    del self.wads[export_path]
-
     def filter_export_paths(self, predicate):
         """Filter paths to export using a predicate
 

--- a/cdtb/hashes.py
+++ b/cdtb/hashes.py
@@ -148,7 +148,7 @@ def progress_iterate(sequence, formatter=None):
     """Iterate over sequence, display progress on SIGINT"""
 
     if formatter is None:
-        formatter = lambda v: v
+        formatter = lambda v: v  # noqa
 
     interrupted = False
     def handler():

--- a/cdtb/patcher.py
+++ b/cdtb/patcher.py
@@ -511,7 +511,7 @@ class PatcherRelease:
         """Download bundles from CDN for the release"""
 
         for elem in self.elements():
-            elem.download(langs=langs)
+            elem.download_bundles(langs=langs)
 
     def extract(self, langs=True, overwrite=False):
         """Extract release files from downloaded bundles"""

--- a/cdtb/rads.py
+++ b/cdtb/rads.py
@@ -442,7 +442,7 @@ class RadsProjectVersion:
     The data in these ProjectVersions are contained in Bin files, which are extracted.
     """
 
-    def __init__(self, project: RadsProject, version: 'Version'):
+    def __init__(self, project: RadsProject, version: RadsVersion):
         self.path = f"{project.path}/{version}"
         self.project = project
         self.version = version
@@ -629,7 +629,7 @@ def parse_rads_component(storage: RadsStorage, component: str):
             return RadsSolutionVersion(solution, RadsVersion(version))
     elif typ == 'patch':
         if version is None:
-            raise ValueError(f"patch requires a version")
+            raise ValueError("patch requires a version")
         elif version == '':
             return storage.patch(None)
         else:

--- a/cdtb/storage.py
+++ b/cdtb/storage.py
@@ -21,11 +21,13 @@ class BaseVersion:
     """
 
     def __init__(self, v: Union[str, tuple]):
+        if not v:
+            raise ValueError(v)
         if isinstance(v, str):
             self.s = v
             self.t = tuple(int(x) for x in v.split('.'))
         elif isinstance(v, tuple):
-            self.s = '.'.join(str(x) for x in v)
+            self.s = '.'.join(str(int(x)) for x in v)
             self.t = v
         else:
             raise TypeError(v)

--- a/cdtb/storage.py
+++ b/cdtb/storage.py
@@ -476,3 +476,9 @@ def parse_storage_component(storage: Storage, component: str) -> Union[None, Pat
         return patch
     else:
         return storage.patch_element(name, version, stored=version is not None)
+
+# Import known storages to register them
+# Put the imports at the end to avoid circular dependenceis
+from . import rads as _rads  # noqa
+from . import patcher as _patcher   # noqa
+

--- a/cdtb/wad.py
+++ b/cdtb/wad.py
@@ -120,7 +120,7 @@ class WadFileHeader:
                 # No subchunk TOC, try to decompress
                 try:
                     return zstd_decompress(data)
-                except:
+                except Exception:
                     raise MalformedSubchunkError(data)
         raise ValueError(f"unsupported file type: {self.type}")
 
@@ -331,5 +331,5 @@ class Wad:
         try:
             return wadfile.read_data(fwad, self.subchunk_toc)
         except MalformedSubchunkError:
-            logger.warning(f"failed to read subchunked wad entry " + (wadfile.path if wadfile.path is not None else f"{wadfile.path_hash:016x}"))
+            logger.warning("failed to read subchunked wad entry " + (wadfile.path if wadfile.path is not None else f"{wadfile.path_hash:016x}"))
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ include = ["/cdtb/*.py"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["cdtb"]
+
+[tool.ruff.lint]
+ignore = ["E741"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import os
-import argparse
 import pytest
 import cdtb
 from cdtb.storage import (
@@ -9,10 +8,7 @@ from cdtb.storage import (
     PatchElement,
 )
 import cdtb.__main__ as cdtb_main
-from cdtb.__main__ import (
-    create_parser,
-    parse_storage_args,
-)
+from cdtb.__main__ import create_parser
 
 
 @pytest.fixture

--- a/tests/test_rads.py
+++ b/tests/test_rads.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from tools import *
+from tools import count_calls, mock_response
 from cdtb.rads import (
     RadsVersion,
     RadsStorage,
@@ -89,7 +89,7 @@ def test_project_get_versions(storage, monkeypatch):
 
     @count_calls
     def request_get(path):
-        assert path == f"projects/name/releases/releaselisting"
+        assert path == "projects/name/releases/releaselisting"
         return mock_response(b'0.0.1.7\r\n0.0.1.6\r\n0.0.1.5\r\n')
     monkeypatch.setattr(storage, 'request_get', request_get)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from cdtb.storage import (
     BaseVersion,
@@ -17,10 +16,12 @@ def test_base_version_init_ok(t, s):
     assert BaseVersion(s).s == s
 
 @pytest.mark.parametrize("arg, exc", [
-    (None, TypeError),
+    (None, ValueError),
     ("", ValueError),
     ((), ValueError),
-    (("1", "2"), TypeError),
+    (("a", "b"), ValueError),
+    # Supported but could be refused
+    #(("1", "2"), ValueError),
 ])
 def test_base_version_init_bad(arg, exc):
     with pytest.raises(exc):
@@ -55,12 +56,12 @@ def test_patch_version_init_ok(arg, t, s):
     assert v.s == s
 
 @pytest.mark.parametrize("arg, exc", [
-    (None, TypeError),
+    (None, ValueError),
     ("", ValueError),
     ("bad", ValueError),
     ("9", AssertionError),
 ])
-def test_base_version_init_bad(arg, exc):
+def test_patch_version_init_bad(arg, exc):
     with pytest.raises(exc):
         PatchVersion(arg)
 


### PR DESCRIPTION
Various fixes and improvements I had locally.
I prefer to push in a separate PR, before pushing changes that really matter.

`ruff` use is not enforced but we could decide to add a CI job to help detect dumb mistakes.