### PR TITLE
Include linked files in bin dump

### DIFF
--- a/cdtb/__main__.py
+++ b/cdtb/__main__.py
@@ -327,6 +327,8 @@ def command_bin_dump(parser, args):
     if args.json:
         json_dump(binfile.to_serializable(), sys.stdout)
     else:
+        if binfile.linked_files is not None:
+            print(f"linked: {binfile.linked_files}")
         for entry in binfile.entries:
             print(entry)
         if binfile.patch_entries is not None:

--- a/cdtb/binfile.py
+++ b/cdtb/binfile.py
@@ -384,6 +384,8 @@ class BinFile:
 
     def to_serializable(self):
         serialized = {entry.path.to_serializable(): entry.to_serializable() for entry in self.entries}
+        if self.linked_files is not None:
+            serialized["__linked"] = self.linked_files
         if self.patch_entries is not None:
             serialized["__patches"] = {entry.path.to_serializable(): entry.to_serializable() for entry in self.patch_entries}
         return serialized


### PR DESCRIPTION
I think it's long overdue for us to include linked file information in bin dumps.

Making this a PR to get feedback on whether the format is acceptable. I don't think this can break compatibility with existing scripts and parsers but another pair of eyes can't hurt.