### PR TITLE
Add tag field in TFT data

### DIFF
--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -221,6 +221,7 @@ class TftTransformer:
                 "associatedTraits": [x.h for x in item.getv("AssociatedTraits", [])], # updated below
                 "incompatibleTraits": [x.h for x in item.getv("IncompatibleTraits", [])], # updated below
                 "effects": collect_effects(item),
+                "tags": [x.h for x in item.getv("ItemTags", [])]
             }
             items.append(item_data)
             items_by_hash[item.path.h] = item_data


### PR DESCRIPTION
One liner to pull the item tags from map22 binary. This is to enable classification of TFT items based on type ie Radiant vs Artifact etc.