### PR TITLE
Change from mDataValues to DataValues

### DIFF
--- a/cdtb/arenadata.py
+++ b/cdtb/arenadata.py
@@ -67,7 +67,7 @@ class ArenaTransformer:
             augment_spellobject = augment.getv(0x1418F849)
             if augment_spellobject:
                 augment_spell = spellobject_entries[augment_spellobject].getv('mSpell')
-                for datavalue in augment_spell.getv('mDataValues', []):
+                for datavalue in augment_spell.getv("DataValues", augment_spell.getv('mDataValues', [])):
                     augment_datavalues[datavalue.getv("mName")] = datavalue.getv("mValues", [0])[0]
 
                 # Giving raw calculations data due to not having a well defined standard

--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -280,7 +280,7 @@ class TftTransformer:
             for entry in tft_bin.entries:
                 if entry.type == "SpellObject" and entry.getv("mScriptName").lower() == spell_name:
                     ability = entry.getv("mSpell")
-                    ability_variables = [{"name": value.getv("mName"), "value": value.getv("mValues")} for value in ability.getv("mDataValues", [])]
+                    ability_variables = [{"name": value.getv("mName"), "value": value.getv("mValues")} for value in ability.getv("DataValues", ability.getv("mDataValues", []))]
                     if loc_keys := ability.get_path("mClientData", "mTooltipData", "mLocKeys"):
                         spell_key_name = loc_keys.get("keyName")
                         spell_key_tooltip = loc_keys.get("keyTooltip")


### PR DESCRIPTION
Riot has changed on PBE datavalue keys from mDataValues to DataValues, this change uses DataValues as the primary with fallback to mDataValues to support past patches