### PR TITLE
Add spell parsing fix for TFTSet17 Units

### DIFF
--- a/cdtb/tftdata.py
+++ b/cdtb/tftdata.py
@@ -263,7 +263,14 @@ class TftTransformer:
 
             tft_bin = BinFile(self_path)
             record = next((x for x in tft_bin.entries if x.type == "TFTCharacterRecord"), {})
-            if "spellNames" not in record:
+            if "spells" in record:
+                spell_ref = next((s for s in record.getv("spells") if s.h != 0), None)
+                spell_match = lambda entry, sr=spell_ref: entry.path == sr
+            elif "spellNames" in record:
+                spell_name = record.getv("spellNames")[0]
+                spell_name = spell_name.rsplit("/", 1)[-1].lower()
+                spell_match = lambda entry, sn=spell_name: entry.getv("mScriptName", "").lower() == sn
+            else:
                 continue
 
             champ_traits = []  # trait paths, as hashes
@@ -273,12 +280,10 @@ class TftTransformer:
                 else:
                     champ_traits.append(trait.h)
 
-            spell_name = record.getv("spellNames")[0]
-            spell_name = spell_name.rsplit("/", 1)[-1].lower()
             spell_key_name = None
             spell_key_tooltip = None
             for entry in tft_bin.entries:
-                if entry.type == "SpellObject" and entry.getv("mScriptName").lower() == spell_name:
+                if entry.type == "SpellObject" and spell_match(entry):
                     ability = entry.getv("mSpell")
                     ability_variables = [{"name": value.getv("name", value.getv("mName")), "value": value.getv("values", value.getv("mValues"))} for value in ability.getv("DataValues", ability.getv("mDataValues", []))]
                     if loc_keys := ability.get_path("mClientData", "mTooltipData", "mLocKeys"):


### PR DESCRIPTION
Now adds missing units to the tft/en_us.json file

Example, TFT17_Graves was missing, now appears as follows:
```
{
                    "ability": {
                        "desc": "<spellPassive>Passive:</spellPassive> Attacks fire @NumProjectiles@ projectiles in a cone that deal <physicalDamage>@ModifiedPassiveDamage@ (%i:TFTBaseAD%)</physicalDamage> physical damage each.<br><br><spellActive>Active:</spellActive> Fire an explosive shell that deals <physicalDamage>@ModifiedDamage@ (%i:scaleAD%)</physicalDamage> physical damage to the target, and <physicalDamage>@ModifiedSecondaryDamage@&nbsp;(%i:scaleAD%%i:scaleAP%)</physicalDamage> physical damage to adjacent enemies.",
                        "icon": "ASSETS/Characters/TFT17_Graves/HUD/Icons2D/TFT17_GravesR.TFT_Set17.tex",
                        "name": "Collateral Damage",
                        "variables": [
                            {
                                "name": "NumProjectiles",
                                "value": [
                                    5.0,
                                    5.0,
                                    5.0,
                                    5.0,
                                    5.0,
                                    5.0,
                                    5.0
                                ]
                            },
                            {
                                "name": "PassivePercentBAD",
                                "value": [
                                    0.33000001311302185,
                                    0.33000001311302185,
                                    0.33000001311302185,
                                    0.33000001311302185,
                                    0.33000001311302185,
                                    0.33000001311302185,
                                    0.33000001311302185
                                ]
                            },
                            {
                                "name": "Damage",
                                "value": [
                                    400.0,
                                    360.0,
                                    540.0,
                                    5555.0,
                                    5555.0,
                                    5555.0,
                                    5555.0
                                ]
                            },
                            {
                                "name": "SecondaryDamageAD",
                                "value": [
                                    120.0,
                                    120.0,
                                    180.0,
                                    3333.0,
                                    3333.0,
                                    3333.0,
                                    3333.0
                                ]
                            },
                            {
                                "name": "SecondaryDamageAP",
                                "value": [
                                    30.0,
                                    30.0,
                                    45.0,
                                    777.0,
                                    777.0,
                                    777.0,
                                    777.0
                                ]
                            }
                        ]
                    },
                    "apiName": "TFT17_Graves",
                    "characterName": "TFT17_Graves",
                    "cost": 5,
                    "icon": "ASSETS/Characters/TFT17_Graves/Skins/Base/Images/TFT17_Graves_splash_centered_18.TFT_Set17.tex",
                    "name": "Graves",
                    "role": "ADCarry",
                    "squareIcon": "ASSETS/Characters/TFT17_Graves/Skins/Base/Images/TFT17_Graves_splash_tile_18.TFT_Set17.tex",
                    "stats": {
                        "armor": 40.0,
                        "attackSpeed": 0.699999988079071,
                        "critChance": 0.25,
                        "critMultiplier": 1.399999976158142,
                        "damage": 57.0,
                        "hp": 900.0,
                        "initialMana": 0,
                        "magicResist": 40.0,
                        "mana": 60.0,
                        "range": 4.0
                    },
                    "tileIcon": "ASSETS/Characters/TFT17_Graves/HUD/TFT17_Graves_Square.TFT_Set17.tex",
                    "traits": [
                        "Factory New"
                    ]
                },
```